### PR TITLE
feat(governance): add agent intent governance (ADR 0014)

### DIFF
--- a/.github/plugins/devsquad/agents/devsquad.agent.md
+++ b/.github/plugins/devsquad/agents/devsquad.agent.md
@@ -9,15 +9,15 @@ agents: ['devsquad.init', 'devsquad.envision', 'devsquad.kickoff', 'devsquad.spe
 
 You are the Spec-Driven Development flow conductor. Your role is to **guide the developer** through the SDD phases, delegating work to sub-agents and mediating interaction.
 
-**You do**: detect state and intent, invoke sub-agents, relay questions to the user, execute actions (create files, work items), maintain cross-phase context, parallelize analyses.
+**You do**: detect state and intent, invoke sub-agents, relay sub-agent questions to the user verbatim, execute actions (create files, work items), maintain cross-phase context via the artifact chain (spec → plan → tasks → code → PR), parallelize analyses only when sub-agent outputs are independent.
 
-**You do NOT**: generate specs/ADRs/code directly, make domain decisions, skip human checkpoints, filter sub-agent questions.
+**You do NOT**: generate specs/ADRs/code directly, make domain decisions, skip human checkpoints, run mutating terminal commands.
 
 Skills: `reasoning`, `board-config`
 
 ## Language
 
-Detect the user's language from their messages or existing non-framework project documents (e.g., specs, README, envisioning docs). Respond and generate all user-facing content in that detected language. When delegating to a sub-agent, include `[LANG: <detected>]` in the handoff prompt so the sub-agent does not need to re-detect. When updating an existing artifact, continue in the artifact's current language. Template section headings (e.g., ## Requirements, ## Acceptance Criteria) are translated to match the artifact language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
+Use the user's language (Copilot adapts naturally). When delegating to a sub-agent, include `[LANG: <detected>]` in the handoff prompt so the sub-agent does not need to re-detect. When updating an existing artifact, continue in the artifact's current language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
 
 ## User Input
 
@@ -29,28 +29,13 @@ $ARGUMENTS
 
 ## Sub-agents
 
-Analyze the user's intent and delegate to the appropriate sub-agent:
+The twelve sub-agents in `agents:` frontmatter are surfaced to you with their `description:` at invocation time; use them directly. Routing decisions specific to this framework:
 
-| Sub-agent | Responsibility |
-|-----------|----------------|
-| `devsquad.init` | Initialize project with SDD Framework files (templates, instructions, configurations) |
-| `devsquad.envision` | Capture strategic vision: customer, business/technical pain points, objectives, success KPIs |
-| `devsquad.kickoff` | Structure project hierarchy (epics, features, dependencies) and sync with board |
-| `devsquad.specify` | Create feature specification: user stories, requirements, compliance criteria |
-| `devsquad.plan` | Technical planning: ADRs, data model, contracts, architecture decisions (Socratic) |
-| `devsquad.decompose` | Decompose specs and ADRs into user stories and tasks, create work items on the board |
-| `devsquad.implement` | Execute implementation from tasks, issues, or work items |
-| `devsquad.security` | Security assessment in architectural mode (design) or code mode (implementation) |
-| `devsquad.review` | Validate implementation against spec, ADRs, and plan. Review log with findings by severity |
-| `devsquad.refine` | Analyze backlog health, detect inconsistencies between artifacts and work items |
-| `devsquad.sprint` | Prepare sprint planning: closure, velocity, capacity, scope options |
-| `devsquad.extend` | Guide creation of extensions (instructions, skills, agents, hooks) for the framework |
-
-When the user mentions a **GitHub issue or Azure DevOps work item**, delegate to `devsquad.implement`.
-When they ask to **extend the framework**, **create a skill/agent/hook/instruction**, or **add stack conventions**, delegate to `devsquad.extend`.
-When they ask to **create a feature** without mentioning framework extension, delegate to `devsquad.specify` (product feature, not framework feature).
-When they ask for **"do everything" or "end-to-end"**, orchestrate multiple phases with checkpoints between each one.
-When they ask to **create a branch, commit, push, or open a PR** for artifacts produced during any phase (envisioning docs, specs, ADRs, plans), handle it directly using terminal commands and GitHub/ADO PR tools. This is artifact management and does not require delegation to `devsquad.implement`. Use the `git-branch`, `git-commit`, and `pull-request` skills for guidance.
+- When the user mentions a **GitHub issue or Azure DevOps work item**, delegate to `devsquad.implement`.
+- When they ask to **extend the framework**, **create a skill/agent/hook/instruction**, or **add stack conventions**, delegate to `devsquad.extend`.
+- When they ask to **create a feature** without mentioning framework extension, delegate to `devsquad.specify` (product feature, not framework feature).
+- When they ask for **"do everything" or "end-to-end"**, orchestrate multiple phases with checkpoints between each one.
+- When they ask to **create a branch, commit, push, or open a PR** for artifacts produced during any phase (envisioning docs, specs, ADRs, plans), handle it directly using terminal commands and GitHub/ADO PR tools. This is artifact management and does not require delegation to `devsquad.implement`. Use the `git-branch`, `git-commit`, and `pull-request` skills for guidance.
 
 ## State Detection
 
@@ -110,31 +95,11 @@ Sub-agents return structured actions that you execute:
 
 ### Question Presentation
 
-When relaying `[ASK]` actions, prefer `vscode_askQuestions` for structured questions. If the tool is unavailable or the call fails, fall back to relaying the question as plain text.
-
-**When to use `askQuestions`**: Questions with identifiable options, scales, or categories (e.g., decision patterns like [A]/[M]/[D], multiple-choice, NEEDS CLARIFICATION markers).
-
-**When to use plain text**: Open-ended narrative questions without clear option boundaries.
-
-**Mapping rules**:
-- Each question block from the sub-agent becomes one `askQuestions` call
-- Free-text questions ("describe...", "who is...", "what are..."): set `allowFreeformInput: true`
-- Questions with listed options (A/B/C, scales, categories): map to `options` array with `label` and `description`
-- Questions where multiple answers apply: set `multiSelect: true`
-- Mark the recommended or default option with `recommended: true`
-- Use the question topic as the `header` value (lowercase, hyphenated, max 50 chars)
+When relaying `[ASK]` actions, prefer `vscode_askQuestions` for questions with discrete options (A/B/C, scales, categories, NEEDS CLARIFICATION markers); use `multiSelect: true` when multiple answers apply, and mark a default with `recommended: true`. Fall back to plain text for open-ended narrative questions or when the tool call fails.
 
 ---
 
 ## Orchestration
-
-### Recommended Flow
-
-```
-init → envision → kickoff → specify → plan → decompose → implement
-```
-
-Alternative scenarios (architecture-first, board-first, PoC, iterative) are documented in the [framework overview](https://microsoft.github.io/devsquad-copilot/framework/).
 
 ### Phase Transition
 

--- a/.github/plugins/devsquad/agents/devsquad.decompose.agent.md
+++ b/.github/plugins/devsquad/agents/devsquad.decompose.agent.md
@@ -10,6 +10,22 @@ handoffs:
 
 Detect the user's language from their messages or existing non-framework project documents and use it for all responses and generated artifacts (specs, ADRs, tasks, work items). When updating an existing artifact, continue in the artifact's current language regardless of the user's message language. Template section headings (e.g., ## Requirements, ## Acceptance Criteria) are translated to match the artifact language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
 
+## Behavioral Constraints
+
+The agent's tool list (`tools:` frontmatter) is the runtime authority. The constraints below are behaviors the agent must honor even when its tools permit otherwise.
+
+- **Disk writes are scoped to `tasks.md`** at the feature or migration path. No source-code edits.
+- **Board writes create user stories, tasks, parent/child links, labels, issue types, and Copilot assignments.** Does not close, delete, or modify unrelated work items.
+- **Terminal commands are read-only board introspection.** No mutating commands outside the board MCP/API.
+
+**Exception gate**: When a story or task cannot be sized or independently tested, surface the issue rather than create an ill-formed item. When the spec lacks a conformance criterion that a task would implement, halt and request a spec amendment via `devsquad.refine`.
+
+### Agent-specific invariant
+
+1. Board items, once created, are not closed or deleted by this agent. GitHub issue closure is driven by PR merge via closing keywords (`Closes #N`, `Fixes #N`, `Resolves #N`) prepared by `devsquad.implement.finalize` in the PR body. Azure DevOps state transitions are handled by `devsquad.implement.finalize` only where appropriate. This agent's responsibility ends at creation and linking.
+
+The task-authoring rules (parent-child structure, tracer-bullet first task, no separate test tasks, missing ADRs as blocking) are documented in `.github/instructions/tasks.instructions.md` and auto-load when this agent edits `tasks.md`. They are not restated here.
+
 ## Conductor Mode
 
 If the prompt starts with `[CONDUCTOR]`, you are a sub-agent of the `sdd` conductor:

--- a/.github/plugins/devsquad/agents/devsquad.implement.agent.md
+++ b/.github/plugins/devsquad/agents/devsquad.implement.agent.md
@@ -16,6 +16,39 @@ handoffs:
 
 Detect the user's language from their messages or existing non-framework project documents and use it for all responses and generated artifacts (specs, ADRs, tasks, work items). When updating an existing artifact, continue in the artifact's current language regardless of the user's message language. Template section headings (e.g., ## Requirements, ## Acceptance Criteria) are translated to match the artifact language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
 
+## Behavioral Constraints
+
+The agent's tool list (`tools:` frontmatter) is the runtime authority. The constraints below are behaviors the agent must honor even when its tools permit otherwise.
+
+- **Disk writes are scoped to the assigned task** in `tasks.md`. Out-of-task file edits, including spec or ADR edits, are forbidden and require an `[AMEND]` invocation of `devsquad.refine`.
+- **Git writes target the feature branch only.** Never `main`, `master`, `develop`, or any branch named in `.memory/git-config.md`. Commits go through the `git-commit` skill (Conventional Commits, Co-authored-by trailer).
+- **PRs open against the integration branch** with `maintainer_can_modify=true` and `draft=true` when work is incomplete.
+- **Never merges PRs.** Merge is always human.
+- **Board writes are status updates and comments only.** Does not create or close work items.
+
+**Sub-agent invocation conditions** (per the `agents:` frontmatter; the conditions below clarify when each runs):
+
+- `validate`: before Medium and High impact execution.
+- `execute`: during task implementation.
+- `verify`: Medium and High impact, or before PR open when required.
+- `finalize`: after `verify` reports pass.
+- `review`: Medium and High impact, before finalization.
+- `refine`: only on confirmed spec or ADR drift.
+
+**Exception gate**: When the spec is silent on a decision the agent would have to make (scope, behavior under failure, API shape), halt and escalate to `devsquad.refine` for a spec amendment. Do not invent the answer.
+
+## Composition
+
+Sub-agents are declared in the `agents:` frontmatter; each carries its own `description:` and `archetype:`. Invocation flow: `validate` → `execute` → `verify` → `finalize`. `devsquad.review` runs between `verify` and `finalize` for Medium and High impact tasks. `devsquad.refine` is invoked when confirmed spec or ADR drift is detected during `validate`, `execute`, or `verify`.
+
+**Cross-component invariants** (hold for every invocation, with impact-level qualifications where noted):
+
+1. `validate` runs before `execute` for Medium and High impact tasks. Low impact may fast-track.
+2. For Medium and High impact tasks, `finalize` opens the PR only after `verify` reports pass on build, tests, coverage, and lint. Low-impact tasks must at minimum pass the detected test command before PR open.
+3. Confirmed spec or ADR drift detected during `validate`, `execute`, or `verify` triggers a handoff to `devsquad.refine` before continuation. Drift that the developer explicitly rejects or defers must be recorded in the reasoning log with rationale. Prompt patches are not a substitute for spec amendments.
+
+Integration-branch protection (no commits to `main`/`master`/`develop`, no merges by any component) is governed by `.github/copilot-instructions.md` and applies across all agents; it is not restated here.
+
 ## Conductor Mode
 
 If the prompt starts with `[CONDUCTOR]`, you are a sub-agent of the `sdd` conductor:

--- a/.github/plugins/devsquad/agents/devsquad.plan.agent.md
+++ b/.github/plugins/devsquad/agents/devsquad.plan.agent.md
@@ -12,6 +12,29 @@ handoffs:
 
 Detect the user's language from their messages or existing non-framework project documents and use it for all responses and generated artifacts (specs, ADRs, tasks, work items). When updating an existing artifact, continue in the artifact's current language regardless of the user's message language. Template section headings (e.g., ## Requirements, ## Acceptance Criteria) are translated to match the artifact language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
 
+## Behavioral Constraints
+
+The agent's tool list (`tools:` frontmatter) is the runtime authority. The constraints below are behaviors the agent must honor even when its tools permit otherwise.
+
+- **Disk writes are scoped to plan and ADR drafts.** Writes `docs/features/<name>/plan.md`, `docs/migrations/<name>/plan.md`, and new ADR drafts under `docs/architecture/decisions/NNNN-domain.md` plus diagrams. Never modifies an `Accepted` ADR without explicit user action.
+- **Terminal commands are analysis-only.** No mutating commands (no `git` writes, no installs that modify lock files, no schema migrations). Enforcement is behavioral; the `execute/runInTerminal` tool has no built-in guard.
+- **Never writes to the board.** Decompose owns work-item creation.
+- **Sub-agent invocation conditions**: `plan.context` first; `plan.architecture` and `plan.design` after; `devsquad.security` when a security trigger is detected (auth, data sensitivity, external network exposure, supply chain).
+
+**Exception gate**: When the spec is ambiguous or contradicts an existing ADR, halt and surface the ambiguity. Do not resolve a contradiction by silently picking one side.
+
+## Composition
+
+Sub-agents are declared in the `agents:` frontmatter; each carries its own `description:` and `archetype:`. Invocation flow: `plan.context` → `plan.architecture` and `plan.design` (which can run in parallel after context). `devsquad.security` is invoked when the spec or design contains a security trigger.
+
+**Cross-component invariants**:
+
+1. `plan.context` runs before `plan.architecture` and `plan.design`. The context drives the analysis; reversing the order produces an unfounded plan.
+2. `devsquad.security` is invoked when the spec or design contains a security trigger (auth, data sensitivity, external network exposure, supply chain). Skipping security on a triggered plan is a calibration failure.
+3. The `plan.md` references each ADR it depends on. Every ADR proposed by this agent is cited from `plan.md`, and every architecture-significant plan decision that requires an ADR (per the Mandatory trade-off explanation rule) cites one. Plan content grounded in the spec, codebase, or established conventions does not require an ADR citation.
+
+The ADR-authoring rules (Proposed status on creation, review before Accepted, priorities-first framing) are documented in `.github/instructions/adrs.instructions.md` and auto-load when this agent creates or edits ADRs; they are not restated here.
+
 ## Conductor Mode
 
 If the prompt starts with `[CONDUCTOR]`, you are a sub-agent of the `sdd` conductor:

--- a/.github/plugins/devsquad/agents/devsquad.refine.agent.md
+++ b/.github/plugins/devsquad/agents/devsquad.refine.agent.md
@@ -24,6 +24,34 @@ handoffs:
 
 Detect the user's language from their messages or existing non-framework project documents and use it for all responses and generated artifacts (specs, ADRs, tasks, work items). When updating an existing artifact, continue in the artifact's current language regardless of the user's message language. Template section headings (e.g., ## Requirements, ## Acceptance Criteria) are translated to match the artifact language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
 
+## Behavioral Constraints
+
+The agent's tool list (`tools:` frontmatter) is the runtime authority. The constraints below are behaviors the agent must honor even when its tools permit otherwise.
+
+- **Disk writes are mode-scoped.** Interactive and conductor modes: single-field edits only (ADR `Status` flips, broken cross-reference paths). `[AMEND]` mode: one spec section, one ADR, or one conformance criterion per invocation with developer confirmation. Multi-section amendments require sequential `[AMEND]` invocations. Source code, tests, and configuration are never edited.
+- **Never writes to git, board, or PRs.** Does not create, close, or modify work items; surfaces stale items as findings.
+- **Sub-agents do not run in `[AMEND]` mode.** Interactive and conductor modes run both `refine.artifacts` and `refine.health`.
+
+**Exception gate**: When a finding cannot be classified into one of the three failure categories in `debugging-recovery/references/failure-taxonomy.md`, log it as `needs-classification` rather than invent a category. When `[AMEND]` mode receives a request that exceeds the scoped surgical edit (touching unrelated sections, multiple specs, or implementation code), halt and request developer confirmation before proceeding.
+
+## Composition
+
+The two sub-Guardians (`refine.artifacts`, `refine.health`) are declared in the `agents:` frontmatter; each carries its own `description:`. They run in interactive and conductor modes; `[AMEND]` mode bypasses them and the parent acts as a focused editor.
+
+| Mode | Trigger | Behavior |
+|---|---|---|
+| Interactive backlog health | No prefix | Run both sub-Guardians, aggregate findings, publish report; surgical edits allowed |
+| Conductor | `[CONDUCTOR]` prefix | Same as interactive but emits structured actions instead of direct user dialogue |
+| Spec Amendment | `[AMEND]` prefix from `devsquad.implement` coordinator | Skip sub-agents, focused scoped edit to one spec section or one ADR, confirmation gate |
+
+**Cross-mode invariants** (hold across all three modes):
+
+1. The aggregated severity of findings is the maximum severity across sub-Guardians. The parent does not downgrade a sub-Guardian's finding. (Interactive and conductor modes.)
+2. Findings that overlap (the same artifact flagged by both sub-Guardians for the same reason) are de-duplicated by the parent; findings that overlap by symptom but differ by upstream artifact remain distinct. (Interactive and conductor modes.)
+3. Amendments in `[AMEND]` mode are scoped: a single spec section, a single ADR, or a single conformance criterion at a time. Multi-section amendments require splitting the request into sequential `[AMEND]` invocations.
+4. Surgical edits in interactive mode are limited to ADR `Status` field changes and broken cross-reference paths. Any other edit must be escalated to `[AMEND]` mode or to a handoff.
+5. When a drift is detected that maps to a failure category in `debugging-recovery/references/failure-taxonomy.md`, the agent surfaces the category name (`spec`, `validation`, or `agent`) and uses it as the Trigger value if an amendment is produced.
+
 ## Operating Modes
 
 This agent runs in one of three modes, selected by the prompt prefix. Modes are mutually exclusive; if multiple prefixes are present, `[AMEND]` wins over `[CONDUCTOR]`, and `[CONDUCTOR]` wins over interactive.
@@ -62,7 +90,7 @@ If the user specifies scope (e.g., "only feature X", "ADRs only"), restrict the 
 
 This agent analyzes **backlog health** by cross-referencing the board state with local artifacts (specs, ADRs, tasks.md). It identifies inconsistencies, stale items, documentation gaps, and silent blockers.
 
-It does not structurally modify artifacts. It can directly fix simple inconsistencies (e.g., ADR status) and offers larger actions via handoff to specialized agents.
+It analyzes backlog health and may make small surgical edits to local artifacts during interactive mode (ADR `Status` flips, broken cross-references). Larger structural changes (new requirements, scope changes, new conformance criteria) go through handoff to specialized agents or through `[AMEND]` mode, never as part of the interactive backlog analysis itself.
 
 It is also invocable **mid-implementation** in Spec Amendment mode (see below), when the implement agent detects that a spec or ADR no longer matches reality.
 
@@ -137,7 +165,7 @@ See the [Spec Amendment During Implementation](https://microsoft.github.io/devsq
 
 ## Operating Principles
 
-- **Read-first, surgical edits**: This agent analyzes and can directly fix simple inconsistencies in local artifacts (e.g., update ADR status, fix broken references). For structural changes or creation of new artifacts, use handoff.
+- **Read-first, surgical edits**: This agent analyzes and may apply small surgical edits to local artifacts in interactive mode (e.g., update ADR `Status` field, fix broken cross-reference path). These edits are scoped to single-field changes; multi-field or section-level edits go through handoff or `[AMEND]` mode. For structural changes or creation of new artifacts, use handoff.
 - **Facts, not opinions**: Report what was found, not what you think should be done.
 - **No false positives**: Only report a problem if there is concrete evidence. When in doubt, omit.
 - **Configurable scope**: The user can restrict the analysis to a feature, epic, or category.

--- a/.github/plugins/devsquad/agents/devsquad.review.agent.md
+++ b/.github/plugins/devsquad/agents/devsquad.review.agent.md
@@ -1,7 +1,7 @@
 ---
 name: devsquad.review
 description: Validate implementation against spec, ADRs, and plan with independent context. Produces a review log with findings by severity.
-tools: ['read/readFile', 'search/changes', 'read/problems', 'search/listDirectory', 'search/textSearch', 'search/fileSearch', 'search/codebase', 'search/usages', 'execute/runInTerminal', 'execute/getTerminalOutput', 'github/pull_request_read', 'github/pull_request_review_write', 'github/add_comment_to_pending_review', 'ado/repo_pull_request', 'ado/repo_pull_request_thread', 'ado/repo_pull_request_thread_write', 'microsoft-learn/microsoft_docs_search', 'microsoft-learn/microsoft_docs_fetch', 'vscode/memory', 'agent']
+tools: ['read/readFile', 'search/changes', 'read/problems', 'search/listDirectory', 'search/textSearch', 'search/fileSearch', 'search/codebase', 'search/usages', 'edit/editFiles', 'edit/createFile', 'edit/createDirectory', 'execute/runInTerminal', 'execute/getTerminalOutput', 'github/pull_request_read', 'github/pull_request_review_write', 'github/add_comment_to_pending_review', 'ado/repo_pull_request', 'ado/repo_pull_request_thread', 'ado/repo_pull_request_thread_write', 'microsoft-learn/microsoft_docs_search', 'microsoft-learn/microsoft_docs_fetch', 'vscode/memory', 'agent']
 agents: ['devsquad.review.spec', 'devsquad.review.adr', 'devsquad.review.code', 'devsquad.review.security', 'devsquad.review.tests']
 handoffs:
   - label: Fix Issues
@@ -19,6 +19,28 @@ handoffs:
 ---
 
 Detect the user's language from their messages or existing non-framework project documents and use it for all responses and generated artifacts (specs, ADRs, tasks, work items). When updating an existing artifact, continue in the artifact's current language regardless of the user's message language. Template section headings (e.g., ## Requirements, ## Acceptance Criteria) are translated to match the artifact language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
+
+## Behavioral Constraints
+
+The agent's tool list (`tools:` frontmatter) is the runtime authority. The constraints below are behaviors the agent must honor even when its tools permit otherwise.
+
+- **Disk writes are limited to the review log** (`docs/features/<name>/review-log.md`, append-only per session). No source-code, spec, or ADR edits.
+- **PR writes are review comments and review state only.** Submit `COMMENT` or `REQUEST_CHANGES`. Never `APPROVE`; approval is the human reviewer's act.
+- **Terminal commands are read-only verification** (run tests, lint, type-check, security scan). Never `git commit`, `git push`, or branch changes.
+- **Never modifies work items.**
+
+**Exception gate**: When a finding cannot be classified without context the agent does not have (e.g., business intent the spec does not capture), the finding is logged as `needs-clarification` rather than escalated as Major.
+
+## Composition
+
+The five sub-Guardians are declared in the `agents:` frontmatter; each carries its own `description:` and `archetype:`. They run in parallel for Medium and High impact changes; the parent aggregates findings into the review log.
+
+**Cross-component invariants**:
+
+1. All five sub-Guardians run for Medium and High impact changes. Low-impact changes may run a reduced set; the reduced set is declared in the review log.
+2. The aggregated severity is the maximum severity across sub-Guardians. The parent does not downgrade a sub-Guardian's finding.
+3. Line-specific findings must include the file path and the line number. Findings without a line location are permitted when the evidence is command-level (failing test output, lint output, security scan result), artifact-level (missing required artifact), or clearly-scoped multi-file (ADR constraint violated across N files, with the N files enumerated). Findings with no evidence at all are not allowed.
+4. False positives flagged by a previous review session are not re-raised by this session unless the underlying code has changed (verified via diff against the prior session's commit).
 
 ## Conductor Mode
 
@@ -442,7 +464,7 @@ If the review is being executed in the context of a PR (provided by the coordina
    ```
 
 3. **Submit review** via `github/pull_request_review_write` (method: `submit`):
-   - If PASSED: event `APPROVE`, body with summary
+   - If PASSED: event `COMMENT`, body summarizing that automated review found no blocking issues. Approval is reserved for the human reviewer (see Governance, invariant 3).
    - If PASSED_WITH_FINDINGS: event `COMMENT`, body with findings summary
    - If FAILED: event `REQUEST_CHANGES`, body with critical findings
 

--- a/.github/plugins/devsquad/agents/devsquad.specify.agent.md
+++ b/.github/plugins/devsquad/agents/devsquad.specify.agent.md
@@ -10,6 +10,15 @@ handoffs:
 
 Detect the user's language from their messages or existing non-framework project documents and use it for all responses and generated artifacts (specs, ADRs, tasks, work items). When updating an existing artifact, continue in the artifact's current language regardless of the user's message language. Template section headings (e.g., ## Requirements, ## Acceptance Criteria) are translated to match the artifact language. Framework-internal identifiers (agent names, skill names, action tags, file paths) always remain in their original form.
 
+## Behavioral Constraints
+
+The agent's tool list (`tools:` frontmatter) is the runtime authority. The constraints below are behaviors the agent must honor even when its tools permit otherwise.
+
+- **Disk writes are scoped to the feature or migration spec** (`docs/features/<name>/spec.md`, `docs/migrations/<name>/spec.md`) and supporting glossary entries. Out-of-feature-scope file edits are forbidden.
+- **Board writes create at most one feature or migration work item per session, with developer confirmation.** Does not close, delete, or modify unrelated work items.
+
+**Exception gate**: When a requirement cannot be specified without an unverified assumption, surface the assumption with an owner rather than invent the answer. When more than three `[NEEDS CLARIFICATION]` markers accumulate, halt the spec and request resolution from the developer.
+
 ## Conductor Mode
 
 If the prompt starts with `[CONDUCTOR]`, you are a sub-agent of the `sdd` conductor:

--- a/.github/plugins/devsquad/hooks/templates/.github/instructions/migration-specs.instructions.md
+++ b/.github/plugins/devsquad/hooks/templates/.github/instructions/migration-specs.instructions.md
@@ -16,6 +16,7 @@ When editing migration specifications, follow these rules:
 - Data Migration must include validation rules (row counts, checksums, referential integrity).
 - Cutover Plan must be an ordered sequence of steps, each with a clear success criterion.
 - Cutover Plan must address consumer redirection explicitly, including delayed consumers (cached DNS or connection strings, queue backlogs, lagging batch jobs) and the mechanism that prevents them from reaching the decommissioned source.
+- Every migration spec must contain a `Spec Evolution Log` section with at least one row recording the current version. Every subsequent change appends a row with version, date, change summary, trigger, and author. Valid trigger values are `new work`, `drift`, `external constraint`, one of the three `failure (<category>)` values defined in `debugging-recovery/references/failure-taxonomy.md` (`spec`, `validation`, `agent`), or `other (<short reason>)` as a transitional escape hatch.
 - Rollback Plan must specify trigger conditions, revert steps, and maximum rollback time.
 - Rollback Plan must state whether the source environment can safely read state produced by the target during the overlap window, or declare that rollback is only viable before a specific cutover step.
 - Success Criteria must include: data integrity metric, downtime metric, parity metric, and rollback test metric.

--- a/.github/plugins/devsquad/hooks/templates/.github/instructions/specs.instructions.md
+++ b/.github/plugins/devsquad/hooks/templates/.github/instructions/specs.instructions.md
@@ -16,6 +16,8 @@ When editing feature specs, follow these rules:
 - Minimum 3 conformance cases: happy path, error scenario, edge case.
 - Maximum 3 [NEEDS CLARIFICATION] markers total.
 - Executive Summary must declare a Change type: `new surface`, `additive to existing`, `modifies existing boundary`, or `removes existing surface`.
+- Executive Summary must declare `Describes AI capability: yes | no`. When `yes`, the spec must complete the `AI Cost Posture` section (model-tier commitment, latency budget, prompt-stability invariant, per-call cost ceiling, cost-incident escalation). Behavioral constraints on the agent belong in the general `Invariants` section; service composition belongs in `Requirements` and `User Scenarios`.
+- Every spec must contain a `Spec Evolution Log` section with at least one row recording the current version. Every subsequent change appends a row with version, date, change summary, trigger, and author. Valid trigger values are `new work`, `drift`, `external constraint`, one of the three `failure (<category>)` values defined in `debugging-recovery/references/failure-taxonomy.md` (`spec`, `validation`, `agent`), or `other (<short reason>)` as a transitional escape hatch.
 - When Change type is not `new surface`, the `Compatibility and Transition` section is required, and at least one compliance case (CC-C*) must cover mixed-version coexistence, delayed consumer behavior, or rollback against state written by the new version.
 - Dates (including `Created on`) default to `YYYY-MM-DD`. Other formats are allowed when the consumer repo has an established convention; once chosen, apply the format consistently across all specs in the repo.
 - Use the template at `docs/features/TEMPLATE.md` as a structure reference.

--- a/.github/plugins/devsquad/hooks/templates/docs/features/TEMPLATE.md
+++ b/.github/plugins/devsquad/hooks/templates/docs/features/TEMPLATE.md
@@ -16,7 +16,20 @@
 - **Value delivered**: [Why it matters]
 - **Scope**: [What is included / excluded]
 - **Change type**: [new surface | additive to existing | modifies existing boundary | removes existing surface]
+- **Describes AI capability**: [yes | no]
 - **Primary success criterion**: [Most important metric]
+
+<!--
+  Describes AI capability:
+    Answer "yes" when the feature embeds an AI agent that makes decisions,
+    invokes tools, or acts on behalf of a user. When "yes", complete the
+    "AI Cost Posture" section below. Behavioral constraints on the agent
+    (rules it must honor even when tools permit) belong in the general
+    Invariants section, not in a separate AI-specific block.
+    Answer "no" for product features that do not embed AI behavior.
+-->
+
+For features whose Change type is not "new surface", recovery semantics belong in the Compatibility and Transition section below.
 
 ## Non-Scope *(required)*
 
@@ -36,6 +49,66 @@
 -->
 
 - [Assumption and basis for making it]
+
+## AI Cost Posture *(required when "Describes AI capability" is "yes"; omit otherwise)*
+
+<!--
+  Complete this section only when the Executive Summary declares
+  "Describes AI capability: yes". This block captures the operational
+  cost commitments the feature makes about the embedded AI behavior.
+
+  Behavioral constraints on the agent (rules it must honor even when
+  tools permit otherwise) belong in the general Invariants section.
+  Service composition (how the AI capability decomposes into sub-services
+  or sub-agents) belongs in Requirements and User Scenarios.
+
+  Model-tier reference (commit one tier per AI step where relevant):
+    Reasoning  - highest reasoning capability, slow, expensive per call
+                 use for: multi-step planning, complex synthesis, hard refactoring
+    Frontier   - state-of-the-art general capability, balanced speed and cost
+                 use for: tool-heavy agents, code generation, conversational UX
+    Mid        - capable but cheaper and faster than frontier
+                 use for: routine summarization, classification with context, RAG
+    Fast       - small, fast, cheap, limited reasoning depth
+                 use for: high-volume classification, simple extraction, latency-critical UX
+
+  When the runtime chooses the model (a managed AI platform or hosted
+  developer assistant where model selection is governed by the platform,
+  not the spec author): set each field to "N/A - model chosen by runtime"
+  and add one line naming what runtime governs the choice. The block
+  still serves as a forcing function: "have we thought about what we
+  are committing to operationally?"
+
+  Placement note: this section appears before User Scenarios because the
+  cost envelope shapes which requirements are economically viable.
+-->
+
+- **Model-tier commitment** (per step where relevant): [step-name to tier (Reasoning / Frontier / Mid / Fast); one-line rationale]
+- **Latency budget**: p50=[value]; p95=[value]; p99=[value]. *Behavior on breach:* [degrade | alert | halt]
+- **Prompt-stability invariant**: [Which prompt elements are guaranteed stable across runs to support caching. What would break the invariant and trigger a spec amendment.]
+- **Per-call cost ceiling**: hard cap=[tokens or dollars]. *Behavior on breach:* [escalate | halt | degrade]
+- **Cost-incident escalation**: [What cost-side condition triggers a stop or human-review gate]
+
+<!--
+  Example (delete when filling this spec for a real feature):
+
+  - Model-tier commitment:
+    - "intent-classify" step -> Fast (high-volume, low-ambiguity classifier)
+    - "draft-summary" step -> Frontier (coherent multi-paragraph output)
+    - "escalation-decision" step -> Reasoning (routes to human; reasoning quality > cost)
+  - Latency budget: p50=400ms; p95=1.2s; p99=3s. Behavior on breach: degrade (skip draft-summary, return classifier output only)
+  - Prompt-stability invariant: system message and tool schema fixed across calls within a 24h window. Tool-schema change triggers a spec amendment.
+  - Per-call cost ceiling: hard cap=$0.05 per ticket. Behavior on breach: escalate (route to human, log incident).
+  - Cost-incident escalation: any 1-hour window where 5% of calls exceed the ceiling triggers a stop and post-mortem.
+
+  Runtime-managed example (use this shape when the platform picks the model):
+
+  - Model-tier commitment: N/A - model chosen by runtime ([platform name] picks per user plan and platform selection logic)
+  - Latency budget: N/A - governed by the runtime platform
+  - Prompt-stability invariant: agent body and tool list are versioned in this repo and changes trigger a CHANGELOG entry
+  - Per-call cost ceiling: N/A - billed via the runtime platform plan
+  - Cost-incident escalation: N/A - cost governed by the runtime platform plan
+-->
 
 ## User Scenarios & Tests *(required)*
 
@@ -235,3 +308,17 @@
 
 - [MS-001: Migration name](../migrations/<short-name>/spec.md) - [Relationship description]
 - [FS-001: Feature name](../features/<short-name>/spec.md) - [Relationship description]
+
+## Spec Evolution Log *(required)*
+
+<!--
+  Every change to this spec is recorded here with its trigger.
+  Captures the spec's version history. The top-level `Status` field
+  remains the source of truth for the spec's current overall lifecycle
+  state (Draft, Approved, In Progress, Validated, Superseded); the log's
+  latest row mirrors that state in its Change Summary column.
+-->
+
+| Version | Date | Change Summary | Trigger | Author |
+|---------|------|----------------|---------|--------|
+| 1.0 | [YYYY-MM-DD] | Initial draft | new work | [Name or role] |

--- a/.github/plugins/devsquad/hooks/templates/docs/migrations/TEMPLATE.md
+++ b/.github/plugins/devsquad/hooks/templates/docs/migrations/TEMPLATE.md
@@ -197,6 +197,7 @@
   3. [Verify source system operational]
   4. [Assess and preserve any data written to target during cutover]
 - **Maximum rollback time**: [X minutes from decision to full revert]
+- **Rollback state compatibility**: [Either "Source can safely read state written by target until step <N>" or "Rollback is only viable before step <N>; after that, forward-fix is required".]
 - **Rollback tested**: [Yes/No, date of last test]
 
 ## Requirements *(required)*
@@ -272,3 +273,17 @@
 
 - [FS-001: Feature name](../features/<short-name>/spec.md) - [Relationship description]
 - [MS-001: Migration name](../migrations/<short-name>/spec.md) - [Relationship description]
+
+## Spec Evolution Log *(required)*
+
+<!--
+  Every change to this spec is recorded here with its trigger.
+  Captures the spec's version history. The top-level `Status` field
+  remains the source of truth for the spec's current overall lifecycle
+  state (Draft, Approved, In Progress, Validated, Superseded); the log's
+  latest row mirrors that state in its Change Summary column.
+-->
+
+| Version | Date | Change Summary | Trigger | Author |
+|---------|------|----------------|---------|--------|
+| 1.0 | [YYYY-MM-DD] | Initial draft | new work | [Name or role] |

--- a/.github/plugins/devsquad/skills/debugging-recovery/SKILL.md
+++ b/.github/plugins/devsquad/skills/debugging-recovery/SKILL.md
@@ -12,6 +12,7 @@ description: Systematic debugging with structured triage. Use when tests fail, b
 - Runtime behavior does not match expectations
 - An error appears in logs or console during implementation
 - Something worked before and stopped working
+- An agent did something its spec, manifest, or oversight model did not authorize (see "Agent-Originated Failures" below)
 
 ## Stop-the-Line Rule
 
@@ -25,6 +26,17 @@ When anything unexpected happens during implementation:
 6. **RESUME** only after verification passes
 
 Do not push past a failing test or broken build to work on the next feature. Errors compound. A bug in step 3 that goes unfixed makes steps 4-10 wrong.
+
+## Failure Source Classification
+
+Before running the triage checklist, decide whether the failure is **agent-originated** (the AI agent did something its spec, manifest, or oversight did not authorize) or **code-originated** (the code, build, or runtime behavior is wrong independently of agent action).
+
+- **Agent-originated** signals: an agent produced an output its spec or composition declaration did not authorize; a sub-agent step was skipped contrary to a coordination contract; a spec gap or ambiguity surfaced as hallucinated behavior; an agent body instruction contradicts a composition invariant.
+- **Code-originated** signals: tests fail without recent agent involvement; build breaks after a dependency upgrade; runtime error in production code; environmental drift between developer machines.
+
+If **agent-originated**, jump to the "Agent-Originated Failures" section below before running the triage checklist. Classify the failure into one of the three categories defined in `references/failure-taxonomy.md`. The upstream artifact (spec, validation surface, or agent file) is where the durable fix goes, not the prompt.
+
+If **code-originated**, proceed with the triage checklist below.
 
 ## Triage Checklist
 
@@ -164,6 +176,20 @@ Runtime error:
   Network error / CORS:   Check URLs, headers, server CORS config
   Unexpected behavior:    Add logging at key points, verify data at each step
 ```
+
+## Agent-Originated Failures
+
+When the failure involves an agent's action (wrong scope, hallucinated output, missed validation, unauthorized write, sub-agent inconsistency), classify the failure category first, then change the upstream artifact that owns the fix. Prompt patches that mask a symptom without reconciling the upstream contradiction are forbidden. Structural edits to the versioned agent body (reconciling a body instruction with a composition invariant, removing an obsolete branch) are not prompt patches; they are legitimate when the upstream artifact is the body itself.
+
+Read `references/failure-taxonomy.md` and select exactly one category:
+
+| Category | Upstream artifact |
+|---|---|
+| `failure (spec)` | `spec.md`, ADR, glossary, or Non-Scope section |
+| `failure (validation)` | Conformance criteria, tests, or quality-gate rubric |
+| `failure (agent)` | Agent file (body or `agents:` frontmatter), composition declaration, MCP/tool config, or handoff |
+
+After amending the upstream artifact, record the amendment in its Spec Evolution Log (or equivalent change log: ADR decision history, agent CHANGELOG entry) with `failure (<category>)` in the Trigger column. The taxonomy file's worked example shows the spec-vs-validation distinction end-to-end.
 
 ## Untrusted Error Output
 

--- a/.github/plugins/devsquad/skills/debugging-recovery/references/failure-taxonomy.md
+++ b/.github/plugins/devsquad/skills/debugging-recovery/references/failure-taxonomy.md
@@ -1,0 +1,29 @@
+# Upstream Fix
+
+When an agent does something wrong, the durable fix lives in an upstream artifact (spec, ADR, validation surface, agent file), not in the prompt that produced the wrong output. Prompt patches that mask a symptom without reconciling the upstream contradiction are leaks; they accumulate and degrade the framework over time.
+
+## Classification
+
+Three categories, each pointing at one upstream artifact:
+
+| Category | When | Upstream artifact | Spec Evolution Log trigger |
+|---|---|---|---|
+| `failure (spec)` | Agent did the wrong thing because the spec was silent, ambiguous, or did not bound scope correctly | `spec.md`, ADR, glossary, or Non-Scope section | `failure (spec)` |
+| `failure (validation)` | The spec required the right behavior but conformance criteria, tests, or quality-gate rubric did not catch the miss | Conformance criteria, tests, or rubric file | `failure (validation)` |
+| `failure (agent)` | Agent body, composition declaration, tool config, or coordination contract was misaligned with the spec | Agent file (body or `agents:` frontmatter), composition declaration, MCP/tool config, or handoff | `failure (agent)` |
+
+Selection test: **Was the expected behavior already required by a normative obligation in the artifact stack?** If no, the failure is `spec`. If yes but the validation surface did not check it, the failure is `validation`. If yes and the validation surface would have caught it but the agent did not reach validation (skipped a step, acted out of role, invoked the wrong sub-agent), the failure is `agent`.
+
+## Worked example
+
+**Symptom**: A consumer's feature spec described a "user signup" flow but did not state what should happen when the email field is empty. The implementation agent generated code that silently accepted empty emails and created accounts with `null` in the `email` column. A downstream service then crashed when it tried to send a welcome email.
+
+**Misclassification trap**: This looks like `failure (validation)` — the test suite did not catch it. It is not. The test suite could not catch behavior the spec did not require. The downstream artifact (test) cannot be expected to cover behavior the upstream artifact (spec) did not specify.
+
+**Classification**: `failure (spec)`.
+
+**Upstream artifact**: `spec.md`. Add a conformance case `CC-005` with input `email=""` and expected output "validation error, account not created". Add a corresponding invariant if appropriate (`accounts.email` is never null when state is `active`).
+
+**Wrong fix (prompt patch)**: telling the implementation agent in its body "always validate email is non-empty before creating an account." Works for this session, not for the next consumer using the plugin without the prompt update.
+
+**Spec Evolution Log row**: `1.1 | YYYY-MM-DD | Added CC-005 (empty email) and invariant on accounts.email | failure (spec) | <author>`.

--- a/.github/plugins/devsquad/skills/quality-gate/SKILL.md
+++ b/.github/plugins/devsquad/skills/quality-gate/SKILL.md
@@ -19,6 +19,7 @@ Use this skill **after generating an artifact and before presenting it to the us
 | `devsquad.plan` | ADRs, plan.md | ADR created or plan finalized |
 | `devsquad.decompose` | tasks.md, work items | Task decomposition completed |
 | `devsquad.implement` | Code | Medium or high impact task implemented |
+| `devsquad.extend` | `*.agent.md` | Custom agent created or modified |
 
 **Do not use for**: low impact tasks (typo, log, formatting), intermediate artifacts that will be reviewed manually, or when the user explicitly asks to skip validation.
 
@@ -118,6 +119,18 @@ Deliver the artifact with documented failures.
 - User explicitly asked to skip: "generate directly", "no validation"
 - Artifact is a declared draft: "draft", "WIP", "exploratory"
 - Re-evaluation of an artifact that already passed (unless it has been modified)
+
+## Recording Failure-Driven Amendments
+
+When `quality-gate` evaluates a spec, ADR, or agent file that was amended in response to a failure (rather than to add new scope), require the Spec Evolution Log Trigger column to use one of the three failure category names from `debugging-recovery/references/failure-taxonomy.md`:
+
+| Trigger value | Use when |
+|---|---|
+| `failure (spec)` | Amendment closes a case the spec did not previously cover, disambiguates a clause, or tightens Non-Scope |
+| `failure (validation)` | Amendment adds a conformance case, test, or rubric criterion the validation surface missed |
+| `failure (agent)` | Amendment fixes a misaligned agent body, composition declaration, tool config, or handoff |
+
+For non-failure triggers (new work, drift detected proactively, external constraint), use `new work`, `drift`, or `external constraint`. For a trigger that does not fit either set, use `other (<short reason>)` as a transitional escape hatch; this raises a quality alert prompting the maintainers to consider whether a new category is warranted.
 
 ## Common Rationalizations
 

--- a/.github/plugins/devsquad/skills/quality-gate/references/rubrica-migration-spec.md
+++ b/.github/plugins/devsquad/skills/quality-gate/references/rubrica-migration-spec.md
@@ -24,6 +24,7 @@ Evaluate each dimension as PASS or FAIL. Each FAIL must include **what is wrong*
 | MS11 | Scope boundaries clear | Out of Scope section exists with at least 1 item. Items explicitly prevent accidental modernization. | Check Out of Scope section |
 | MS12 | Executive summary complete | Contains: objective, source environment, target environment, scope, downtime target, primary success criterion. | Check 6 points |
 | MS13 | Clarification limit | Maximum 3 [NEEDS CLARIFICATION] markers. Each has a specific question and described impact. | Count markers |
+| MS14 | Spec Evolution Log present | Spec contains a Spec Evolution Log section with at least one row (version, date, change summary, trigger, author). | Check Spec Evolution Log section |
 
 ## Cross-Verification (deep level)
 

--- a/.github/plugins/devsquad/skills/quality-gate/references/rubrica-spec.md
+++ b/.github/plugins/devsquad/skills/quality-gate/references/rubrica-spec.md
@@ -10,6 +10,7 @@ Evaluate each dimension as PASS or FAIL. Each FAIL must include **what is wrong*
 | S2 | Conformance criteria | Minimum 3 cases: happy path, error, and edge. At least one negative case (must NOT happen). Each case has ID, scenario, input, and expected output. | Check CC-XXX table |
 | S3 | Prioritized user stories | Every user story has priority (P1/P2/P3) and is independently testable. | Check user stories section |
 | S4 | Defined scope | An out of scope section exists with at least 1 item. | Check section |
+| S13 | AI Cost Posture complete | When the Executive Summary declares `Describes AI capability: yes`, the AI Cost Posture section is present with all five fields populated (model-tier commitment, latency budget, prompt-stability invariant, per-call cost ceiling, cost-incident escalation). When the gate is `no`, this criterion is N/A. | Read AI Cost Posture section |
 
 ## Quality Criteria (FAIL generates alert, does not block)
 
@@ -21,6 +22,7 @@ Evaluate each dimension as PASS or FAIL. Each FAIL must include **what is wrong*
 | S8 | Executive summary | Contains: objective (1 sentence), primary user, delivered value, scope, main success criterion. | Check 5 points |
 | S9 | Invariants | For features with state mutations or external integrations, cross-cutting properties that must always hold are documented. | Check Invariants section |
 | S10 | Failure modes | For features with external dependencies or shared state, failure conditions (timeouts, partial failures, concurrency) are documented. | Check Failure Modes subsection |
+| S11 | Spec Evolution Log present | Spec contains a Spec Evolution Log section with at least one row (version, date, change summary, trigger, author). | Check Spec Evolution Log section |
 
 ## Cross-Verification (deep level)
 

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -38,6 +38,7 @@ This project was shaped by ideas, patterns, and prior art from many sources acro
 | [Compatibility is a Feature](https://yusufaytas.com/compatibility-is-a-feature) by Yusuf Aytas | Mixed-version coexistence, rollback-against-state, and boundary-drift thinking that shaped the Compatibility and Transition section in feature specs |
 | [Harness Engineering](https://martinfowler.com/articles/harness-engineering.html) by Martin Fowler | Feedforward/feedback taxonomy for coding agent controls that shaped the harness-learnings skill and hook output contract |
 | [Harness Engineering: Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/) (OpenAI) | Steering loop and layered architecture enforcement patterns that informed the two-tier learning mechanism in ADR-0013 |
+| [The Architecture of Intent](https://marcelaldecoa.github.io/TheArchitectureOfIntent/) by Marcel Aldecoa | Discipline for agent-class governance: behavioral envelope on agents, composition declarations on coordinators, fix-at-the-upstream-artifact failure routing, and cost commitments on AI-capability specs. Selectively adopted in ADR-0014, with parts of the source vocabulary (custom frontmatter scalars, Reversibility tier, Pattern A/B/C/D/E taxonomy, seven-category failure taxonomy) deliberately left out. |
 
 ## Design Patterns and Standards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,55 @@ compatibility-focused categories that always appear at the top of a release:
 
 See `CONTRIBUTING.md` for full conventions.
 
+## [Unreleased]
+
+### Added (Agent Intent Governance — selective Architecture of Intent adoption)
+
+Closes three structural gaps in the framework: framework agents had no explicit behavioral envelope (a reviewer reading `devsquad.implement.agent.md` could not determine in under a minute what the agent was authorized to do, must never do, or how it composes sub-agents); consumer specs describing AI capabilities had no canonical fragment for operational cost commitments; the failure-diagnosis surface had no taxonomy mapping a failure to the upstream artifact that owns the fix. Vocabulary and discipline drawn from "The Architecture of Intent" by Marcel Aldecoa (`https://marcelaldecoa.github.io/TheArchitectureOfIntent/`). The framework adopts the load-bearing principles and deliberately omits parts of the source vocabulary that add no behavior (see "AoI constructs considered and not adopted" in ADR 0014).
+
+**Agent body conventions:**
+
+- `## Behavioral Constraints` body section on 7 user-facing agents (`devsquad`, `devsquad.implement`, `devsquad.plan`, `devsquad.review`, `devsquad.refine`, `devsquad.specify`, `devsquad.decompose`). Captures rules the runtime `tools:` array cannot enforce (for example, "never APPROVE on a PR", "never commits to integration branch"). Worker sub-agents (`*.execute`, `*.verify`, `*.finalize`, `*.validate`, `*.context`, `*.architecture`, `*.design`, `*.code`, `*.tests`, `*.spec`, `*.adr`, `*.security`, `*.artifacts`, `*.health`) carry no manifest; they inherit their envelope from the parent's composition declaration and from their own `description:` frontmatter, which the runtime surfaces at invocation time.
+- `## Composition` body section on 4 coordinator agents (`devsquad.implement`, `devsquad.plan`, `devsquad.review`, `devsquad.refine`). Declares load-bearing cross-component invariants between the coordinator and its typed sub-agents (for example, `validate` runs before `execute` for Medium and High impact tasks; `plan.context` runs before `plan.architecture` and `plan.design`; the parent never downgrades a sub-Guardian's severity finding).
+
+**Template changes (consumer action required):**
+
+- **Feature spec template** (`docs/features/TEMPLATE.md`):
+  - New `Spec Evolution Log` section. Required on every spec, with at least one row at creation time. Each amendment adds a row with version, date, change summary, trigger, and author. Trigger values include `failure (spec)`, `failure (validation)`, `failure (agent)`, plus `new work`, `drift`, `external constraint`, or `other (<short reason>)`.
+  - New `Describes AI capability: yes | no` field in the Executive Summary.
+  - New gated `## AI Cost Posture` section, required only when `Describes AI capability` is `yes`. Five fields: model-tier commitment (Reasoning / Frontier / Mid / Fast per AI step, with one-line rationale), latency budget (p50, p95, p99, behavior on breach), prompt-stability invariant, per-call cost ceiling, cost-incident escalation. Author-facing comment block includes a tier reference (capability profile and typical use per tier) and an N/A pattern for runtime-managed scenarios where the platform picks the model. Non-AI specs see no AI-specific structure.
+- **Migration spec template** (`docs/migrations/TEMPLATE.md`):
+  - New `Spec Evolution Log` section, same shape as the feature template.
+- **Spec instruction files** (`.github/instructions/specs.instructions.md`, `.github/instructions/migration-specs.instructions.md`):
+  - New rule requiring the Spec Evolution Log and the three valid `failure (<category>)` trigger values.
+  - Feature spec rule additionally requires `Describes AI capability: yes | no` in the Executive Summary and a complete `AI Cost Posture` section when `yes`.
+- **Spec quality rubrics** (`rubrica-spec.md`, `rubrica-migration-spec.md`): new criterion checking presence of Spec Evolution Log; feature rubric additionally checks AI Cost Posture completeness when the gate is `yes`.
+
+Consumers running `sdd-init.sh update-all` after upgrading will see these files rewritten (a timestamped `.pre-<version>-<unix>.bak` is saved automatically). Existing specs authored from the previous template remain valid; the Spec Evolution Log and Executive Summary additions are additive and not retroactive.
+
+**Failure-diagnosis surface:**
+
+- `failure-taxonomy.md` reference file added to the `debugging-recovery` skill. Three-category upstream-artifact principle: `failure (spec)` (artifact: `spec.md`, ADR, glossary, or Non-Scope section), `failure (validation)` (artifact: conformance criteria, tests, or rubric file), `failure (agent)` (artifact: agent file body or `agents:` frontmatter, composition declaration, MCP/tool config, or handoff). One worked example shows the spec-vs-validation distinction end-to-end (silent empty-email field in a signup flow).
+- `debugging-recovery/SKILL.md` Failure Source Classification step routes agent-originated failures into the three categories before triage.
+- `quality-gate/SKILL.md` Recording Failure-Driven Amendments uses the same three categories as canonical Spec Evolution Log trigger values.
+- `devsquad.refine.agent.md` Exception gate references the three categories when classifying findings.
+
+**Architecture Decision Record:**
+
+- ADR 0014 "Agent Intent Governance" added at `docs/framework/decisions/0014-agent-intent-governance.md`. Records the structural gaps, the five ranked priorities, the three options considered (full AoI adoption rejected; selective adoption adopted; status quo rejected), the adopted scope (four constructs above), and the AoI constructs considered and explicitly not adopted (custom frontmatter scalars, Reversibility tier, Pattern A/B/C/D/E composition taxonomy, seven-category failure taxonomy, standalone authoring handbook, AoI signal metrics, phase rename).
+- ADR list page (`docs/src/content/docs/decisions/index.mdx`) includes ADR 0014 in the published decisions index.
+
+### Not adopted from AoI
+
+The source vocabulary in "The Architecture of Intent" includes constructs this release deliberately omits because they add documentation surface without changing what the framework does in response. The reasoning for each is recorded in ADR 0014 under "AoI constructs considered and not adopted in this option":
+
+- Custom frontmatter scalars (`archetype`, `agency_level`, `autonomy`, `responsibility`, `reversibility`, `oversight_model`).
+- Reversibility tier (R1-R4) on spec templates.
+- AoI Pattern A/B/C/D/E composition taxonomy labels.
+- Seven-category failure taxonomy (collapsed to three).
+- Standalone `agent-conventions.md` distributed handbook.
+- AoI signal metrics, running scenarios, phase rename.
+
 ## [v0.12.0] - 2026-05-09
 
 ### Template changes (consumer action required)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -83,6 +83,7 @@ items: [
 { label: 'Impact Classification', slug: 'concepts/impact-classification', badge: { text: 'Core', variant: 'tip' } },
 { label: 'Comprehension Checkpoints', slug: 'concepts/comprehension-checkpoints', badge: { text: 'Core', variant: 'tip' } },
 { label: 'Spec Amendment', slug: 'concepts/spec-amendment', badge: { text: 'Core', variant: 'tip' } },
+{ label: 'AI Capability Specs', slug: 'concepts/ai-capability-specs' },
 { label: 'Implementation Rules', slug: 'guardrails/implementation' },
 { label: 'Team Coordination', slug: 'guardrails/team-coordination' },
 ],

--- a/docs/framework/decisions/0014-agent-intent-governance.md
+++ b/docs/framework/decisions/0014-agent-intent-governance.md
@@ -1,0 +1,98 @@
+# Agent Intent Governance
+
+* **Status**: Accepted
+* **Date**: 2026-05-14
+
+## Context
+
+The framework ships a suite of delegated executors (`devsquad.*` agents) and instructs consumer repos to author specs that those agents implement. Two structural gaps surfaced while evaluating the discipline described in "The Architecture of Intent" (AoI):
+
+* The framework's own agents (specify, plan, decompose, implement, review, plus the sub-agent fleet) have no explicit behavioral envelope. A reviewer reading `devsquad.implement.agent.md` cannot determine, in under a minute, what the agent is authorized to do, what it must never do (beyond the runtime `tools:` array), and how it composes its sub-agents.
+* The spec template (`.github/plugins/devsquad/hooks/templates/docs/features/TEMPLATE.md`) treats every feature as a product feature. Consumer teams using devsquad to spec AI-agent capabilities in their own products have no template fragment for behavioral constraints or operational cost commitments. They either reinvent the structure ad hoc or omit it.
+
+A third, smaller gap exists in the failure-diagnosis surface (`debugging-recovery`, `quality-gate`): there is no upstream-artifact taxonomy that maps a failure to the artifact that should change. Patches accumulate in prompts and agent files instead of in specs or composition declarations.
+
+AoI offers a vocabulary that addresses these gaps directly. The decision is which parts of that vocabulary to adopt, in what scope, with what enforcement.
+
+## Priorities and Requirements (ordered)
+
+1. **Preserve the existing SDD spine** (Envision, Specify, Plan, Decompose, Implement, Review). The phase names, agent IDs, marketplace plugin manifest, and consumer documentation must continue to work without rename or migration.
+2. **Close the agent-class governance gap, both internally and externally**. Coordinator agents that own a side-effect surface must declare their behavioral envelope. Consumer specs that embed AI behavior must have a canonical block for operational cost commitments.
+3. **Avoid ceremony for non-agent specs**. Most consumer features are product features, not AI capabilities. Forcing AI-specific structure on every spec would generate noise and erode adoption.
+4. **Keep changes additive and non-breaking**. Existing specs, ADRs, agents, and consumer repos must remain valid after the change. No mandatory migration scripts.
+5. **Make failures diagnosable by upstream artifact**. When an agent misbehaves, the upstream artifact that owns the fix must be identifiable from the failure category, so corrections compound structurally rather than as prompt patches.
+
+## Options Considered
+
+### Option 1: Full AoI adoption (replace template, rename phases, add signal metrics)
+
+Adopt the canonical 12-section AoI spec template wholesale. Rename Envision, Specify, Plan, Decompose, Implement, Review to Frame, Specify, Delegate, Validate, Evolve. Introduce the four AoI signal metrics (spec-gap rate, first-pass validation, cost per correct outcome, oversight load) with telemetry infrastructure to collect them.
+
+**Evaluation against priorities**:
+
+* **Preserve SDD spine**: Fails. Phase rename breaks agent IDs, marketplace manifest, instructions, consumer documentation, and the muscle memory of every adopting team.
+* **Close governance gap**: Meets. The 12-section template covers it.
+* **Avoid ceremony for non-agent specs**: Fails. AoI's template is built for agent systems; forcing every feature spec through 12 sections including Archetype Declaration adds significant overhead for product-feature specs that do not need it.
+* **Additive and non-breaking**: Fails. Wholesale replacement is breaking by definition.
+* **Failures diagnosable by upstream artifact**: Meets. AoI's failure taxonomy ships with the framework.
+
+### Option 2: Selective adoption (gated AI block on feature specs, behavioral envelope on agents, upstream-artifact taxonomy)
+
+Adopted. Four targeted constructs layered onto the existing framework:
+
+1. `## Behavioral Constraints` body section on user-facing agents (5 coordinators plus `specify` and `decompose`). Captures rules the runtime `tools:` array cannot enforce (e.g., "never APPROVE on a PR", "never commits to integration branch"). Worker sub-agents carry no manifest; they inherit their envelope from their parent's composition declaration and their own `description:` frontmatter.
+2. Spec Evolution Log section in feature and migration spec templates, plus a gated `AI Cost Posture` block in the feature template (model-tier commitment, latency budget, prompt-stability invariant, per-call cost ceiling, cost-incident escalation). The block is gated by `Describes AI capability: yes/no`; when `no`, the block is omitted and the template is unchanged in size for the reader. Behavioral constraints on AI-capability specs use the general `Invariants` section; composition uses the general `Requirements` and `User Scenarios` sections.
+3. `## Composition` body section on 4 coordinator agents (`devsquad.implement`, `devsquad.plan`, `devsquad.review`, `devsquad.refine`). Declares load-bearing cross-component invariants between the coordinator and its typed sub-agents. The runtime surfaces each sub-agent's `description:` at invocation time, so the section does not re-list sub-agents.
+4. Three-category upstream-artifact failure taxonomy (`failure (spec)`, `failure (validation)`, `failure (agent)`) in `debugging-recovery`, with one worked example showing the spec-vs-validation distinction. Each category maps to one upstream artifact that owns the fix. `quality-gate` consults the same three categories when recording failure-driven amendments in the Spec Evolution Log trigger column.
+
+**Evaluation against priorities**:
+
+* **Preserve SDD spine**: Meets. No phase rename, no agent ID change, no breaking removal.
+* **Close governance gap**: Meets. Coordinator agents that own the side-effect surface declare their behavioral envelope. Consumer specs that embed AI behavior have a canonical AI Cost Posture block.
+* **Avoid ceremony for non-agent specs**: Meets. The gate keeps non-AI specs unchanged in shape. The only universal addition is the Spec Evolution Log (small, replaces the implicit Status plus Version pair).
+* **Additive and non-breaking**: Meets. All additions are optional or gated. Existing specs remain valid.
+* **Failures diagnosable by upstream artifact**: Meets. The three-category taxonomy ships as a reference file in `debugging-recovery` and is referenced by `quality-gate`.
+
+**AoI constructs considered and not adopted in this option**:
+
+* Custom frontmatter scalars on agents (`archetype`, `agency_level`, `autonomy`, `responsibility`, `reversibility`, `oversight_model`). The GitHub Copilot runtime does not consume custom frontmatter keys; the scalars would be inert documentation competing for credibility with the operational fields the runtime reads (`name`, `description`, `tools`, `agents`, `handoffs`, `model`). The behavioral envelope ships in body sections instead.
+* Reversibility tier (R1-R4) on spec templates. The migration template's existing `Rollback Plan` section captures rollback semantics directly (maximum rollback time, state compatibility). Feature specs use the existing `Compatibility and Transition` section for the same concern. A categorical tier on top of these is taxonomy without behavioral effect.
+* AoI Pattern A/B/C/D/E composition taxonomy. The labels carry no behavioral effect; the cross-component invariants in the `## Composition` section carry the actual contract. The labels are AoI vocabulary that ages with the source material rather than the framework's behavior.
+* Seven-category failure taxonomy. Multiple AoI categories (Spec Gap, Spec Ambiguity, Scope Expansion) share one upstream artifact (`spec.md`); the finer granularity did not change what the framework does in response. The collapse to three categories preserves the diagnostic discipline without the vocabulary surface area.
+* A standalone `agent-conventions.md` distributed handbook. Plugin authors learn from existing agents in the repo's `agents/` directory and from the inline structure of the agent files themselves; a separate handbook duplicates the runtime contract and creates documentation drift.
+* AoI signal metrics, running scenarios, phase rename. Out of scope per priority 1 (preserve SDD spine).
+
+### Option 3: Status quo (no AoI adoption)
+
+Leave the framework as is. Document the AoI vocabulary in an internal reference but make no template, agent, or skill changes.
+
+**Evaluation against priorities**:
+
+* **Preserve SDD spine**: Meets trivially.
+* **Close governance gap**: Fails. Both gaps persist. Agent files remain opaque about their authority, and consumer agent specs continue to be ad hoc.
+* **Avoid ceremony for non-agent specs**: Meets trivially.
+* **Additive and non-breaking**: Meets trivially.
+* **Failures diagnosable by upstream artifact**: Fails. The upstream-artifact taxonomy gap persists. Corrections continue to accumulate in prompts.
+
+## Decision
+
+Adopt Option 2 (Selective adoption).
+
+Rationale, tied to the ranked priorities:
+
+* Option 2 is the only option that meets priorities 1, 2, 3, 4, and 5 simultaneously. Option 1 sacrifices priorities 1, 3, 4 for marginal gains on priorities 2 and 5 that Option 2 already delivers. Option 3 sacrifices priorities 2 and 5 entirely.
+* The framework's strongest property is that it is small and opinionated. Option 2 preserves that property by gating new structure behind a single declaration (`Describes AI capability: yes/no`) and keeping the new agent body sections optional-by-position but present where the agent governs delegated work.
+* Self-application is the most defensible adoption. The framework's own agents are exactly the delegated executors AoI is built to govern. The agent governance work and the composition declarations on coordinator agents are the highest-leverage moves available without changing what the framework looks like to a consumer who is not building agent capabilities.
+
+The implementation lands in the framework `CHANGELOG.md` under the next release entry. This ADR is the structural commitment; the CHANGELOG entry is the catalogue of what shipped.
+
+## Implementation Notes
+
+1. All template changes carry the standard provenance header (`<!-- devsquad-template: ... vX.Y.Z sha=... -->`) and require a version bump in both `plugin.json` copies plus a `CHANGELOG.md` entry.
+2. The four copy-source templates (`docs/features/TEMPLATE.md`, `docs/migrations/TEMPLATE.md`, `docs/envisioning/TEMPLATE.md`, `docs/architecture/decisions/ADR-TEMPLATE.md`) continue to carry no inline provenance header. The manifest lock remains their sole provenance source.
+3. The four constructs in the Decision are independently reviewable. The order between them is enforced by content (body sections must exist before `quality-gate` can enforce them; failure taxonomy must reference agent body fields), not by ADR.
+4. The four AoI signal metrics, the running scenarios, the pattern catalog, and the phase rename remain out of scope.
+
+## References
+
+* "The Architecture of Intent" by Marcel Aldecoa, documentation site at `https://marcelaldecoa.github.io/TheArchitectureOfIntent/`

--- a/docs/src/content/docs/concepts/ai-capability-specs.mdx
+++ b/docs/src/content/docs/concepts/ai-capability-specs.mdx
@@ -1,0 +1,123 @@
+---
+title: AI Capability Specs
+description: How to write a feature spec that describes an AI agent capability, including the gated AI Cost Posture block with model-tier, latency, prompt-stability, cost-ceiling, and escalation commitments.
+banner:
+  content: |
+    This project is under active development and subject to breaking changes. See the <a href="/devsquad-copilot/changelog/">changelog</a> for release notes.
+---
+
+import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
+
+Most consumer features are product features. Some features embed AI behavior: an agent that classifies, summarizes, plans, or acts on behalf of a user. AI features carry a class of commitments product features do not: which model tier the feature relies on, what latency it promises, what it costs per call, and what happens when those bounds break.
+
+The framework treats AI-capability specs as ordinary feature specs with one gated addition: the **AI Cost Posture** block.
+
+## The Executive Summary Gate
+
+Every feature spec declares this in the Executive Summary:
+
+```text
+- Describes AI capability: yes | no
+```
+
+- **Answer `no`** when the feature is a product feature with no embedded AI behavior. The AI Cost Posture section is omitted. The template looks the same as any non-AI spec.
+- **Answer `yes`** when the feature embeds an AI agent that makes decisions, invokes tools, or acts on behalf of a user. The AI Cost Posture section becomes required.
+
+The gate is the only AI-specific question on a product feature spec. Authors who answer `no` see no AI-specific structure for the rest of the document.
+
+## The AI Cost Posture Block
+
+When the gate is `yes`, the spec must populate five fields. The fields commit the feature to operational characteristics that downstream operators measure and that future amendments must honor.
+
+### Model-tier commitment
+
+Which model tier the feature commits to, per AI step where multiple steps exist.
+
+<CardGrid>
+  <Card title="Reasoning">
+    Highest reasoning capability, slow, expensive per call. Use for multi-step planning, complex synthesis, hard refactoring.
+  </Card>
+  <Card title="Frontier">
+    State-of-the-art general capability, balanced speed and cost. Use for tool-heavy agents, code generation, conversational UX.
+  </Card>
+  <Card title="Mid">
+    Capable but cheaper and faster than frontier. Use for routine summarization, classification with context, RAG.
+  </Card>
+  <Card title="Fast">
+    Small, fast, cheap, limited reasoning depth. Use for high-volume classification, simple extraction, latency-critical UX.
+  </Card>
+</CardGrid>
+
+A spec with multiple AI steps commits a tier per step with a one-line rationale. The tier is the durable commitment; the specific model is chosen at implementation time and may change as the platform's lineup shifts.
+
+### Latency budget
+
+Three percentile values plus a behavior on breach:
+
+- `p50`, `p95`, `p99` latency targets.
+- Behavior on breach: `degrade` (skip an optional step), `alert` (notify operators), or `halt` (refuse to serve).
+
+The budget is what the operator measures the implementation against. A breach is a signal that either the implementation drifted or the spec under-committed.
+
+### Prompt-stability invariant
+
+Which prompt elements are guaranteed stable across runs to support caching, and what would break the invariant. A typical statement: "the system message and tool schema are fixed across calls within a 24-hour window. A tool-schema change triggers a spec amendment."
+
+The invariant matters for two reasons: prompt caches are a major cost lever, and a silent prompt change is one of the easiest ways for an AI capability to drift away from its spec without anyone noticing.
+
+### Per-call cost ceiling
+
+A hard cap in tokens or dollars per call, plus a behavior on breach: `escalate` (route to human), `halt` (refuse to serve), or `degrade` (fall back to a cheaper path).
+
+The ceiling is the financial guarantee. A call that exceeds it is a cost incident, not a normal cost variation.
+
+### Cost-incident escalation
+
+What cost-side condition triggers a stop or human-review gate. Typical example: "any 1-hour window where 5% of calls exceed the per-call ceiling triggers a stop and post-mortem."
+
+This is the trip wire. The other four fields establish a budget; this one names what trips a human-in-the-loop intervention.
+
+## When the Platform Picks the Model
+
+The five fields presuppose that the spec author operates the AI service: chooses the model, pays per token, monitors latency. That fits one common scenario (a team building an AI product on top of OpenAI, Anthropic, Azure OpenAI, or similar).
+
+The other common scenario is a team consuming a managed AI platform where the runtime picks the model: a hosted developer assistant, an embedded AI feature in another product, or any surface where model selection is governed by the platform rather than the spec.
+
+For runtime-managed scenarios, set each field to `N/A - model chosen by runtime` and add one line per field naming what runtime governs the choice. A worked example:
+
+```text
+- Model-tier commitment: N/A - model chosen by runtime
+  ([platform name] picks per user plan and platform selection logic)
+- Latency budget: N/A - governed by the runtime platform
+- Prompt-stability invariant: agent body and tool list are versioned in
+  this repo; changes trigger a CHANGELOG entry
+- Per-call cost ceiling: N/A - billed via the runtime platform plan
+- Cost-incident escalation: N/A - cost governed by the runtime platform plan
+```
+
+The block still serves as a forcing function: it asks whether the team has thought about what they are committing to operationally. If the honest answer is "nothing, the platform picks", that answer is the commitment.
+
+## What Does Not Go in This Block
+
+Three categories of content that AI-capability specs sometimes try to put in the AI Cost Posture block but that belong elsewhere in the feature template:
+
+| Content type | Where it goes instead |
+|---|---|
+| Behavioral constraints (rules the agent must honor even when tools permit otherwise) | The general `## Invariants` section. "Never APPROVE on a PR" or "never commits to integration branch" are not AI-specific concerns; they apply to any service surface. |
+| Service composition (how the AI capability decomposes into sub-services, sub-agents, or steps) | The general `## Requirements` and `## User Scenarios` sections. The architecture of an AI capability follows the same rules as any other feature's architecture. |
+| Failure modes specific to AI (model unavailability, hallucination, drift) | The general `## Failure Modes` subsection under Requirements. Treat AI-specific failures the same way as any other external dependency failure. |
+
+The AI Cost Posture block carries exactly the content that has no general-template equivalent: operational commitments tied to model selection.
+
+## Related
+
+- [Spec Amendment](../../concepts/spec-amendment/): when an AI capability's behavior drifts from its spec, route the fix to the upstream artifact rather than patching the prompt.
+- [Glossary](../../concepts/glossary/): canonical definitions for AI Cost Posture, Behavioral Constraints, and related terms.
+- [ADR 0014](../../decisions/#adr-0014-agent-intent-governance-): the structural decision behind the gated block and the constructs considered but not adopted.
+
+---
+
+## What to Read Next
+
+- [Spec Amendment](../../concepts/spec-amendment/) for how AI capability specs evolve when implementation reveals a gap
+- [Impact Classification](../../concepts/impact-classification/) for how AI-capability changes are sized

--- a/docs/src/content/docs/concepts/glossary.mdx
+++ b/docs/src/content/docs/concepts/glossary.mdx
@@ -13,7 +13,13 @@ import { Aside } from '@astrojs/starlight/components';
 **ADR (Architecture Decision Record)**
 A document that records a significant technical decision, including context, priorities, options evaluated, and the chosen approach with trade-offs. ADRs follow the lifecycle: `Proposed`, then `Accepted`, then `Superseded by NNNN`. See [Decisions](../../decisions/).
 
+**AI Cost Posture**
+A gated section in the feature spec template, required when the spec declares `Describes AI capability: yes`. Captures five operational commitments: model-tier (Reasoning, Frontier, Mid, or Fast per AI step), latency budget (p50, p95, p99 plus behavior on breach), prompt-stability invariant, per-call cost ceiling, and cost-incident escalation. For platforms where the runtime picks the model, fields are set to `N/A` with a one-line note. See [AI Capability Specs](../../concepts/ai-capability-specs/).
+
 ## C
+
+**Behavioral Constraints (agent body section)**
+A `## Behavioral Constraints` section on a user-facing agent file listing rules the agent must honor even when its runtime `tools:` array would permit otherwise (for example, "never APPROVE on a PR"; "never commits to integration branch"). The `tools:` list is the runtime authority boundary; this section captures only what the runtime cannot enforce. Present on the seven user-facing agents (`devsquad`, `devsquad.implement`, `devsquad.plan`, `devsquad.review`, `devsquad.refine`, `devsquad.specify`, `devsquad.decompose`); worker sub-agents inherit their envelope from the parent.
 
 **Comprehension Checkpoint**
 A verification step triggered before medium or high impact tasks. The agent asks the developer to describe what will happen in their own words, ensuring active understanding rather than passive delegation. Generic responses ("ok", "go") trigger deeper questions. See [Comprehension Checkpoints](../../concepts/comprehension-checkpoints/).
@@ -26,6 +32,9 @@ Testable conditions (identified by CC-XXX format) that verify a specification re
 
 **Coordinator Agent**
 A specialist agent that delegates internally to focused worker sub-agents with isolated context. The framework has four coordinators: `plan`, `implement`, `review`, and `refine`.
+
+**Composition (agent body section)**
+A `## Composition` section on a coordinator agent file declaring load-bearing cross-component invariants between the coordinator and its typed sub-agents (for example, `validate` runs before `execute` for Medium and High impact tasks). The runtime surfaces each sub-agent's `description:` at invocation time, so the section does not re-list sub-agents.
 
 ## D
 
@@ -73,6 +82,9 @@ The development approach where specifications drive all downstream work: plannin
 **Socratic AI**
 An adaptive approach where agents ask clarifying questions, surface trade-offs, and present options rather than making autonomous decisions. Low-impact tasks are fast-tracked; high-impact tasks require comprehension verification. Based on [ADR 0005](../../decisions/#adr-0005-socratic-ai-).
 
+**Spec Evolution Log**
+A required section in every feature and migration spec that records amendment history. Each row carries version, date, change summary, trigger (`new work`, `drift`, `external constraint`, one of three `failure (<category>)` values, or `other (<short reason>)`), and author. The log is the durable signal that the spec changed and why. See [Spec Amendment](../../concepts/spec-amendment/).
+
 **Specialist Agent**
 An agent that owns the logic for a specific delivery phase (e.g., `devsquad.specify` for specifications, `devsquad.implement` for code). Can be invoked directly or through the conductor.
 
@@ -83,6 +95,11 @@ A threat modeling methodology (Spoofing, Tampering, Repudiation, Information Dis
 
 **Tool Extension**
 A mechanism for injecting MCP server tools into existing plugin agents via YAML patches (Preview, [ADR 0010](../../decisions/#adr-0010-agent-tool-extension-)). Consumer creates `.github/devsquad/tool-extensions/*.yml`, and a sync script generates workspace-level agent overrides.
+
+## U
+
+**Upstream Fix (Failure Triage)**
+The discipline of routing an agent-originated failure to the upstream artifact that owns the broken rule, instead of patching the prompt. Three categories: `failure (spec)` (fix in `spec.md`, ADR, or glossary), `failure (validation)` (fix in conformance criteria, tests, or rubric), `failure (agent)` (fix in agent body, composition declaration, or tool config). Prompt patches that mask a symptom without reconciling the upstream artifact are forbidden. See [Spec Amendment](../../concepts/spec-amendment/#failure-driven-amendment).
 
 ## W
 

--- a/docs/src/content/docs/concepts/spec-amendment.mdx
+++ b/docs/src/content/docs/concepts/spec-amendment.mdx
@@ -159,6 +159,56 @@ Amendments follow the same impact classification as any other change:
 | New/changed conformance case within a story | Medium | Scoped refine, developer confirms |
 | User story boundary change, new entity, NFR change | High | Amendment plus ADR update, explicit approval |
 
+## Spec Evolution Log
+
+Every feature and migration spec carries a `Spec Evolution Log` section. The log is the durable record of what changed about the spec and why. Without it, the third reader of a spec cannot tell which clauses are original intent and which were amendments responding to discovered reality.
+
+The log is a table with one row per version:
+
+| Column | Content |
+|---|---|
+| Version | Semantic version of the spec (`1.0` at creation, increments per amendment) |
+| Date | ISO date of the change |
+| Change summary | One-sentence description of what changed |
+| Trigger | Why the change happened, drawn from the enumerated values below |
+| Author | Who authored the change |
+
+Valid trigger values:
+
+| Trigger | When to use |
+|---|---|
+| `new work` | Adding scope, requirements, or scenarios in response to product direction |
+| `drift` | Reconciling the spec with implementation reality discovered during the work |
+| `external constraint` | Compliance, vendor change, platform deprecation, or other outside force |
+| `failure (spec)` | Amendment closes a case the spec was silent on, or disambiguates a clause that admitted two readings |
+| `failure (validation)` | Amendment adds a conformance case, test, or rubric criterion the validation surface missed |
+| `failure (agent)` | Amendment fixes a misaligned agent body, composition declaration, or tool config |
+| `other (<short reason>)` | Transitional escape hatch when none of the above fit. Raises a quality alert prompting maintainers to consider a new category. |
+
+The three `failure (<category>)` triggers tie the log to the framework's upstream-fix discipline (described in the next section).
+
+## Failure-Driven Amendment
+
+Not every amendment is product-direction or implementation-discovery. Some amendments are **failure-driven**: an agent did the wrong thing, and the durable fix is to amend the upstream artifact that owns the rule the agent broke. Prompt patches that mask the symptom without reconciling the upstream artifact are forbidden; they accumulate and degrade the framework.
+
+When an agent-originated failure surfaces, classify it into one of three categories and route the fix to the named upstream artifact:
+
+| Category | When | Upstream artifact |
+|---|---|---|
+| `failure (spec)` | Agent did the wrong thing because the spec was silent, ambiguous, or did not bound scope correctly | `spec.md`, ADR, glossary, or Non-Scope section |
+| `failure (validation)` | The spec required the right behavior but conformance criteria, tests, or the quality-gate rubric did not catch the miss | Conformance criteria, tests, or rubric file |
+| `failure (agent)` | Agent body, composition declaration, tool config, or coordination contract was misaligned with the spec | Agent file (body or `agents:` frontmatter), composition declaration, or handoff |
+
+Selection test: **Was the expected behavior already required by a normative obligation in the artifact stack?**
+
+- If **no**, the failure is `spec`. The validation surface could not catch what the spec did not require.
+- If **yes** but the validation surface did not check it, the failure is `validation`.
+- If **yes** and the validation surface would have caught it but the agent skipped a step, acted out of role, or invoked the wrong sub-agent, the failure is `agent`.
+
+After amending the upstream artifact, record the change in the Spec Evolution Log with the matching `failure (<category>)` value in the Trigger column. The category name is the durable signal that the framework learned from a failure rather than from new product direction.
+
+Worked examples and category-selection guidance live in the `failure-taxonomy.md` reference file in the `debugging-recovery` skill.
+
 ## Related
 
 - [Impact Classification](../../concepts/impact-classification/): amendment ceremony scales with risk in the same way task ceremony does.

--- a/docs/src/content/docs/decisions/index.mdx
+++ b/docs/src/content/docs/decisions/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture Decisions
-description: All 12 Architecture Decision Records documenting significant technical decisions.
+description: All 14 Architecture Decision Records documenting significant technical decisions.
 banner:
   content: |
     This project is under active development and subject to breaking changes. See the <a href="/devsquad-copilot/changelog/">changelog</a> for release notes.
@@ -131,6 +131,30 @@ ADR 0011 is now historical context. ADR 0012 documents the current nested sub-ag
 **Decision**: Use coordinator + worker patterns for complex agents. `plan`, `implement`, `review`, and `refine` delegate to focused worker sub-agents with isolated context and parallel fan-out where tasks are independent.
 
 **Trade-off**: More agent files and orchestration logic in exchange for cleaner context boundaries, lower bias during validation, and lower latency for independent checks.
+
+---
+
+## ADR 0013: Harness Learnings <Badge text="Proposed" variant="caution" />
+
+**Problem**: Agents repeat the same self-correction loop session after session because there is no mechanism to capture and consult codebase-specific operational knowledge across sessions.
+
+**Priorities**: (1) Zero-friction capture, (2) Immediate availability, (3) Whole-lifecycle coverage, (4) Self-curation, (5) Path to durability, (6) Low context cost, (7) Consistency with existing patterns.
+
+**Decision**: Store learnings in `.memory/harness-learnings.md` (workspace-local, structured markdown) via a new `harness-learnings` skill. Two-tier lifecycle: Tier 1 captures with confidence scoring and auto-pruning; Tier 2 promotes proven learnings to permanent harness controls (instructions, hooks, skill amendments) via `devsquad.extend`.
+
+**Trade-off**: Workspace-local file means learnings do not automatically propagate across team members; the Tier 2 promotion path is the mechanism for sharing. Accepted in exchange for zero-friction capture and immediate availability without release cycles.
+
+---
+
+## ADR 0014: Agent Intent Governance <Badge text="Accepted" variant="success" />
+
+**Problem**: Framework agents had no declared behavioral envelope; consumer specs describing AI-agent capabilities had no template fragment for the same; failures accumulated as prompt patches rather than structural amendments.
+
+**Priorities**: (1) Preserve the existing SDD spine (no phase rename), (2) Close the agent-class governance gap both internally and externally, (3) Avoid ceremony for non-agent specs, (4) Keep changes additive and non-breaking, (5) Make failures diagnosable by upstream artifact.
+
+**Decision**: Selective adoption from "The Architecture of Intent" (Marcel Aldecoa). `## Behavioral Constraints` body section on user-facing agents (rules `tools:` cannot enforce). `## Composition` body section with cross-component invariants on coordinators. Spec Evolution Log in feature and migration spec templates. Gated `AI Cost Posture` block in the feature spec template (model-tier, latency budget, prompt stability, cost ceiling, escalation) for specs that embed AI behavior. Three-category upstream-artifact failure taxonomy (`spec`, `validation`, `agent`) in `debugging-recovery`.
+
+**Trade-off**: Imports the load-bearing AoI principles for agent-class governance without adopting the four AoI signal metrics, custom frontmatter scalars, pattern taxonomy, or phase rename. Non-agent specs are unaffected.
 
 ---
 


### PR DESCRIPTION
This PR introduces additional engineering discipline inspired by [The Architecture of Intent](https://marcelaldecoa.github.io/TheArchitectureOfIntent/) to close three structural gaps:

- Framework agents had no explicit behavioral envelope; coordinator agents now declare `Behavioral Constraints` (rules tools cannot enforce) and `Composition` (cross-component invariants).
- Consumer specs describing AI capabilities had no canonical fragment for operational cost commitments; the feature template now carries a gated `AI Cost Posture` block (model tier, latency budget, prompt stability, per-call cost ceiling, cost-incident escalation), opted into via `Describes AI capability: yes` metadata in the Executive Summary.
- The failure diagnosis surface on the `debugging-recovery` skill had no taxonomy mapping a failure to the upstream artifact that owns the fix. Now it ships a three-category upstream-artifact principle - `failure (spec)`, `failure (validation)`, `failure (agent)`.

Spec evolution log added to feature and migration spec templates with the three failure trigger values. Docs site gains a new concept page (AI Capability Specs), two new sections in Spec Amendment, and five glossary entries.

ADR 0014 records the decision, options considered, and the AoI constructs deliberately not adopted (custom frontmatter scalars, Reversibility tier, Pattern A/B/C/D/E taxonomy, seven-category failure taxonomy, standalone authoring handbook, signal metrics, phase rename). AoI attribution added to ACKNOWLEDGMENTS under Articles and Blog Posts.

CHANGELOG entry filed under [Unreleased]; manifest versions unchanged (release bump deferred to release commit).